### PR TITLE
fix: Bitmap to byte[] compile error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules
 /android/build
 /android/RCTWeChat.iml
 
-# ios
+# iOS
 ios/build
 
 # Xcode
@@ -15,3 +15,6 @@ Pods/
 *.ipa
 *.dSYM.zip
 *.dSYM
+
+# Android
+.idea

--- a/android/src/main/java/com/theweflex/react/WeChatModule.java
+++ b/android/src/main/java/com/theweflex/react/WeChatModule.java
@@ -62,10 +62,17 @@ public class WeChatModule extends ReactContextBaseJavaModule implements IWXAPIEv
     private final static String INVALID_ARGUMENT = "invalid argument.";
     private final static int THUMB_SIZE = 32; // The size of thumb image in KB.
 
-    private static byte[] bitmapTopBytes(Bitmap bitmap) {
+    private static byte[] bitmapTopBytes(Bitmap bitmap, final boolean needRecycle) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         bitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
-        bitmap.recycle();
+        if (needRecycle) {
+            bitmap.recycle();
+        }
+        try {
+			baos.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
         return baos.toByteArray();
     }
 
@@ -241,7 +248,7 @@ public class WeChatModule extends ReactContextBaseJavaModule implements IWXAPIEv
             if (thumb.length() / 1024 > THUMB_SIZE) {
                 message.thumbData = bitmapResizeGetBytes(thumb, THUMB_SIZE);
             } else {
-                message.thumbData = thumb;
+                message.thumbData = bitmapTopBytes(thumb, true);
             }
         }
 


### PR DESCRIPTION
fix: assign bitmap to thumbData cause error,  message.thumbData is byte[] type [doc](https://developers.weixin.qq.com/doc/oplatform/Mobile_App/Share_and_Favorites/Android.html)